### PR TITLE
Disable RSpec/LetSetup cop

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1079,3 +1079,6 @@ Security/Eval:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - "spec/**/*"
+RSpec/LetSetup:
+  Description: Using let! in configuration is not a bad thing if well structured
+  Enabled: false


### PR DESCRIPTION
From discussions on FD the team agreed that allowing `let!` for spec setup is not a bad thing, and I agree with that.

We are a bunch of clever people and know how to proper structure specs, so using `let!` is not a problem :)