### PR TITLE
Fix deprecation errors

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -76,10 +76,6 @@ Style/Encoding:
   Description: Use UTF-8 as the source file encoding.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#utf-8
   Enabled: false
-  EnforcedStyle: always
-  SupportedStyles:
-  - when_needed
-  - always
 Naming/FileName:
   Description: Use snake_case for source file names.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#snake-case-files

--- a/default.yml
+++ b/default.yml
@@ -1003,10 +1003,6 @@ Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
   Enabled: false
-Lint/InvalidCharacterLiteral:
-  Description: Checks for invalid character literals with a non-escaped whitespace
-    character.
-  Enabled: false
 Lint/LiteralInCondition:
   Description: Checks of literals used in conditions.
   Enabled: false

--- a/lib/reinteractive/style/version.rb
+++ b/lib/reinteractive/style/version.rb
@@ -1,5 +1,5 @@
 module Reinteractive
   module Style
-    VERSION = "0.2.2".freeze
+    VERSION = "0.2.3".freeze
   end
 end


### PR DESCRIPTION
This PR fixes the following deprecation errors:

```
Error: The `Lint/InvalidCharacterLiteral` cop has been removed since it was never being actually triggered.
(obsolete configuration found in /Users/gabrielgizotti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/reinteractive-style-0.2.2/default.yml, please update it)
```
```
obsolete parameter EnforcedStyle (for Style/Encoding) found in /Users/gabrielgizotti/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/reinteractive-style-0.2.2/default.yml
Style/Encoding no longer supports styles. The "never" behavior is always assumed.
```