### PR TITLE
Feature/allow multiple expectations per spec

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -1074,3 +1074,6 @@ Lint/AmbiguousBlockAssociation:
 RSpec/LetSetup:
   Description: Using let! in configuration is not a bad thing if well structured
   Enabled: false
+RSpec/MultipleExpectations:
+  Description: Multiple expectations in a spec are fine if used with caution
+  Enabled: false

--- a/default.yml
+++ b/default.yml
@@ -126,7 +126,6 @@ Style/IfUnlessModifier:
   Description: Favor modifier if/unless usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#if-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
 Style/LambdaCall:
   Description: Use lambda.call(...) instead of lambda.(...).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
@@ -331,7 +330,6 @@ Style/WhileUntilModifier:
   Description: Favor modifier while/until usage when you have a single-line body.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#while-as-a-modifier
   Enabled: false
-  MaxLineLength: 80
 Style/WordArray:
   Description: Use %w or %W for arrays of words.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#percent-w

--- a/reinteractive-style.gemspec
+++ b/reinteractive-style.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.50.0"
+  spec.add_dependency "rubocop", "~> 0.52.0"
   spec.add_dependency "rubocop-rspec", "~> 1.15"
 
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
This PR does the following:

- Disable the `RSpec/MultipleExpectations` cop
- Bump rubocop dependecy version to 0.5.2