### PR TITLE
Fix warnings

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 reinteractive
+Copyright (c) 2018 reinteractive
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/default.yml
+++ b/default.yml
@@ -609,7 +609,7 @@ Style/OneLineConditional:
   Description: Favor the ternary operator(?:) over if/then/else/end constructs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#ternary-operator
   Enabled: false
-Naming/BinaryOperatorParameter:
+Naming/BinaryOperatorParameterName:
   Description: When defining binary operators, name the argument other.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#other-arg
   Enabled: false
@@ -931,9 +931,15 @@ Layout/SpaceAroundOperators:
 Layout/SpaceAroundKeyword:
   Description: Put a space before the modifier keyword.
   Enabled: true
-Layout/SpaceInsideBrackets:
-  Description: No spaces after [ or before ].
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-spaces-braces
+Layout/SpaceInsideBlockBraces:
+  Description: >-
+                 Checks that block braces have or don't have surrounding space.
+                 For blocks taking parameters, checks that the left brace has
+                 or doesn't have trailing space.
+  Enabled: true
+Layout/SpaceInsideHashLiteralBraces:
+  Description: Use spaces inside hash literal braces - or don't.
+  StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-operators
   Enabled: true
 Layout/SpaceInsideParens:
   Description: No spaces after ( or before ).
@@ -997,7 +1003,7 @@ Lint/HandleExceptions:
   Description: Don't suppress exception.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#dont-hide-exceptions
   Enabled: false
-Lint/LiteralInCondition:
+Lint/LiteralAsCondition:
   Description: Checks of literals used in conditions.
   Enabled: false
 Lint/LiteralInInterpolation:

--- a/lib/reinteractive/style/version.rb
+++ b/lib/reinteractive/style/version.rb
@@ -1,5 +1,5 @@
 module Reinteractive
   module Style
-    VERSION = "0.2.4".freeze
+    VERSION = "0.2.5".freeze
   end
 end

--- a/reinteractive-style.gemspec
+++ b/reinteractive-style.gemspec
@@ -29,8 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.52.0"
-  spec.add_dependency "rubocop-rspec", "~> 1.15"
+  spec.add_dependency "rubocop", "~> 0.52.1"
+  spec.add_dependency "rubocop-rspec", "~> 1.21.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/reinteractive-style.gemspec
+++ b/reinteractive-style.gemspec
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "reinteractive/style/version"


### PR DESCRIPTION
A few cops have been renamed in Rubocop gem, so I've renamed them here as well in order to fix the following warnings:

```sh
$ rubocop
Warning: unrecognized cop Naming/BinaryOperatorParameter found in ~/.rvm/gems/ruby-2.5.0/gems/reinteractive-style-0.2.4/default.yml
Warning: unrecognized cop Layout/SpaceInsideBrackets found in ~/.rvm/gems/ruby-2.5.0/gems/reinteractive-style-0.2.4/default.yml
Warning: unrecognized cop Lint/LiteralInCondition found in ~/.rvm/gems/ruby-2.5.0/gems/reinteractive-style-0.2.4/default.yml
```