### PR TITLE
Remove the Include array

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -2,11 +2,6 @@ require: rubocop-rspec
 
 AllCops:
   DisplayCopNames: true
-  Include:
-    - "**/**/*.rake"
-    - "**/Gemfile"
-    - "**/Rakefile"
-    - '**/config.ru'
   Exclude:
     - "vendor/**/*"
     - "db/**/*"

--- a/reinteractive-style.gemspec
+++ b/reinteractive-style.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.54"
+  spec.add_dependency "rubocop", "~> 0.57"
   spec.add_dependency "rubocop-rspec", "~> 1.24"
 
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
Remove the Include files from the default.yml
They are now the default, and my having this it means that when you run rubocop on your project it doesn't check anything.

I've tested this my pointing my project at a local checkout of this gem

# Flowdock history (edited):

Craig at 15:24
Hi @team, wondering what I’ve setup wrong, I’ve got gem "reinteractive-style” in group :development
but when I run rubocop, it seems to avoid most of the files
```
➜  aidacare-cmp git:(develop) rubocop
Inspecting 3 files
...

3 files inspected, no offenses detected
➜  aidacare-cmp git:(develop) rubocop app/models/user.rb
Inspecting 0 files
0 files inspected, no offenses detected
```

@Craig, I was having the same problem 15:57
 LucasLucas at 15:55

I think the reason is this change: https://github.com/Drenmi/rubocop/commit/0c9e80ed3bb216a419b354958b7125310493bca0

so when you specify any file in AllCops/Include, it'll ignore Rubocop defaults

@Craig we have to get rid of these lines: https://github.com/reinteractive/reinteractive-style/blob/develop/default.yml#L5-L9
Thanks @Lucas  I’ll try that locally

@Craig all of these ⬆️ are included in Rubocop's new default 🙂



