### PR TITLE
fix: fixed error caused by renamed configuration

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -948,7 +948,7 @@ Layout/SpaceInsideRangeLiteral:
   Description: No spaces inside range literals.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-space-inside-range-literals
   Enabled: true
-Layout/Tab:
+Layout/IndentationStyle:
   Description: No hard tabs.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#spaces-indentation
   Enabled: true
@@ -991,7 +991,7 @@ Lint/EmptyEnsure:
 Lint/EmptyInterpolation:
   Description: Checks for empty string interpolation.
   Enabled: true
-Lint/EndInMethod:
+Style/EndBlock:
   Description: END blocks should not be placed inside method definitions.
   Enabled: true
 Lint/EnsureReturn:


### PR DESCRIPTION
Fixed error as below:

```
Error: The `Layout/Tab` cop has been renamed to `Layout/IndentationStyle`.
(obsolete configuration found in /home/vagrant/.rvm/gems/ruby-2.6.5/bundler/gems/reinteractive-style-76fb0cb56963/default.yml, please update it)
The `Lint/EndInMethod` cop has been renamed to `Style/EndBlock`.
(obsolete configuration found in /home/vagrant/.rvm/gems/ruby-2.6.5/bundler/gems/reinteractive-style-76fb0cb56963/default.yml, please update it)
```