### PR TITLE
Update rubocop version to handle ruby 3.1

### DIFF
--- a/lib/reinteractive/style/version.rb
+++ b/lib/reinteractive/style/version.rb
@@ -1,5 +1,5 @@
 module Reinteractive
   module Style
-    VERSION = "0.2.10".freeze
+    VERSION = "0.3.0".freeze
   end
 end

--- a/reinteractive-style.gemspec
+++ b/reinteractive-style.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop", "~> 0.57"
+  spec.add_dependency "rubocop", "~> 1.14"
   spec.add_dependency "rubocop-rails", "~> 2.5"
-  spec.add_dependency "rubocop-rspec", "~> 1.24"
+  spec.add_dependency "rubocop-rspec", "~> 2.0.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
Updates rubocop and rubocop-rspec to handle ruby 3.1